### PR TITLE
Fix #4: Fix bug in replace method of Equality.

### DIFF
--- a/src/model/formulas/Equality.java
+++ b/src/model/formulas/Equality.java
@@ -18,8 +18,8 @@ public class Equality extends Formula {
     
     @Override
     public Formula replace(Term newTerm,Term oldTerm){
-    	Term lhsRet = this.lhs.equals(oldTerm) ? newTerm : oldTerm;
-    	Term rhsRet = this.rhs.equals(oldTerm) ? newTerm : oldTerm;
+    	Term lhsRet = this.lhs.equals(oldTerm) ? newTerm : this.lhs;
+    	Term rhsRet = this.rhs.equals(oldTerm) ? newTerm : this.rhs;
     	return new Equality(lhsRet, rhsRet);
     }
     


### PR DESCRIPTION
Fixes #4. Before the fix, if the LHS/RHS didn't match oldTerm, it replaced the corresponding side with oldTerm. Instead if it doesn't match, the term shouldn't change.